### PR TITLE
Move video to hero section background with autoplay loop

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,16 @@ function createApp() {
       <!-- Hero Section with enhanced accessibility -->
       <main id="main-content">
         <section id="hero" class="hero-section finisher-header" aria-labelledby="hero-title">
+          <div class="hero-video-background">
+            <iframe
+              src="https://www.youtube.com/embed/5fpGTE3aIw0?autoplay=1&mute=1&loop=1&playlist=5fpGTE3aIw0&controls=0&showinfo=0&rel=0&modestbranding=1"
+              title="MindWave.AI product demonstration video background"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              loading="eager">
+            </iframe>
+          </div>
+          <div class="hero-overlay"></div>
           <div class="container">
             <h1 id="hero-title" class="hero-title">MindWave.AI</h1>
             <p class="hero-subtitle">
@@ -49,18 +59,6 @@ function createApp() {
             <button class="cta-button" id="hero-cta" aria-label="Discover the future of neural technology">
               Discover the Future
             </button>
-            <div class="video-showcase">
-              <div class="video-container">
-                <iframe
-                  src="https://www.youtube.com/embed/5fpGTE3aIw0?autoplay=1&mute=1&loop=1&playlist=5fpGTE3aIw0"
-                  title="MindWave.AI product demonstration video showing advanced neural interface technology"
-                  frameborder="0"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  allowfullscreen
-                  loading="lazy">
-                </iframe>
-              </div>
-            </div>
           </div>
         </section>
 

--- a/src/style.css
+++ b/src/style.css
@@ -278,6 +278,8 @@ a:focus-visible {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
+  position: relative;
+  z-index: 2;
 }
 
 .hero-section {
@@ -289,9 +291,53 @@ a:focus-visible {
   text-align: center;
   padding: 100px 20px 120px;
   position: relative;
-  background: var(--hero-gradient);
   color: var(--text-light);
   overflow: hidden;
+}
+
+.hero-video-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.hero-video-background::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(10, 14, 39, 0.5);
+  z-index: 1;
+}
+
+.hero-video-background iframe {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100vw;
+  height: 56.25vw;
+  min-height: 100vh;
+  min-width: 177.77vh;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(10, 14, 39, 0.7) 0%, rgba(26, 35, 126, 0.6) 50%, rgba(13, 71, 161, 0.6) 100%);
+  z-index: 1;
+  pointer-events: none;
 }
 
 /* Disabled wave overlay - using finisher-header animation instead
@@ -737,41 +783,7 @@ a:focus-visible {
   color: var(--gray-600);
 }
 
-.video-showcase {
-  width: 100%;
-  max-width: 900px;
-  margin: 60px auto 0;
-  position: relative;
-  z-index: 2;
-}
-
-.video-container {
-  position: relative;
-  width: 100%;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  background: var(--glass-bg);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--glass-border);
-  border-radius: 24px;
-  overflow: hidden;
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.3);
-  transition: all 0.3s ease;
-}
-
-.video-container:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 35px 70px rgba(0, 0, 0, 0.4);
-}
-
-.video-container iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-  border-radius: 24px;
-}
+/* Video showcase styles removed - now using background video in hero */
 
 .specifications-section {
   padding: 120px 0;
@@ -1168,10 +1180,6 @@ a:focus-visible {
     margin: 0;
   }
 
-  .video-showcase {
-    max-width: 100%;
-    margin: 40px 16px 0;
-  }
 
   .price {
     font-size: 48px;


### PR DESCRIPTION
## Summary
- Moved YouTube video from showcase element to full-screen background in hero section
- Video now plays automatically in a continuous loop behind hero content
- Added gradient overlay for improved text readability
- Removed video controls for cleaner background appearance

## Changes
- Updated `src/main.js`: Restructured hero section HTML with video background and overlay layers
- Updated `src/style.css`: Added video background styles with full-screen coverage and z-index layering

## Test plan
- [ ] Verify video plays automatically on page load
- [ ] Confirm video loops continuously in background
- [ ] Check text remains readable over video background
- [ ] Test responsiveness on mobile devices
- [ ] Ensure video doesn't interfere with hero CTA interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)